### PR TITLE
Extend timeout by default for slower systems

### DIFF
--- a/k3s.service
+++ b/k3s.service
@@ -13,6 +13,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
+TimeoutSec=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On fresh Raspbian install on a Raspberry Pi 3B+, I was seeing `systemctl` timeouts. I think for weak / small systems we should default to extending the timeouts on a systemd service.